### PR TITLE
feat: add --quiet and --json flags for CLI automation

### DIFF
--- a/src/praxis/cli.py
+++ b/src/praxis/cli.py
@@ -76,32 +76,57 @@ def init_cmd(
         "-f",
         help="Overwrite existing files.",
     ),
+    json_output: bool = typer.Option(
+        False,
+        "--json",
+        help="Output JSON format.",
+    ),
+    quiet: bool = typer.Option(
+        False,
+        "--quiet",
+        "-q",
+        help="Suppress non-error output.",
+    ),
 ) -> None:
     """Initialize a new Praxis project."""
-    # Interactive prompts if flags not provided
-    if domain is None:
-        domain_choices = [d.value for d in Domain]
-        domain = typer.prompt(
-            "Domain",
-            default="code",
-            show_choices=True,
-            type=click.Choice(domain_choices),
-        )
-    if privacy is None:
-        privacy_choices = [p.value for p in PrivacyLevel]
-        privacy = typer.prompt(
-            "Privacy level",
-            default="personal",
-            show_choices=True,
-            type=click.Choice(privacy_choices),
-        )
+    # Interactive prompts if flags not provided (disabled in json/quiet mode)
+    if json_output or quiet:
+        if domain is None or privacy is None:
+            error_msg = "--domain and --privacy required with --json or --quiet"
+            if json_output:
+                typer.echo('{"success": false, "errors": ["' + error_msg + '"]}')
+            else:
+                typer.echo(f"✗ {error_msg}", err=True)
+            raise typer.Exit(1)
+    else:
+        if domain is None:
+            domain_choices = [d.value for d in Domain]
+            domain = typer.prompt(
+                "Domain",
+                default="code",
+                show_choices=True,
+                type=click.Choice(domain_choices),
+            )
+        if privacy is None:
+            privacy_choices = [p.value for p in PrivacyLevel]
+            privacy = typer.prompt(
+                "Privacy level",
+                default="personal",
+                show_choices=True,
+                type=click.Choice(privacy_choices),
+            )
 
     result = init_project(path, domain, privacy, environment, force)
 
+    if json_output:
+        typer.echo(result.model_dump_json(indent=2))
+        raise typer.Exit(0 if result.success else 1)
+
     if result.success:
-        typer.echo("✓ Praxis project initialized")
-        for f in result.files_created:
-            typer.echo(f"  Created: {f}")
+        if not quiet:
+            typer.echo("✓ Praxis project initialized")
+            for f in result.files_created:
+                typer.echo(f"  Created: {f}")
         raise typer.Exit(0)
     else:
         for err in result.errors:
@@ -116,12 +141,28 @@ def stage_cmd(
         Path("."),
         help="Project directory.",
     ),
+    json_output: bool = typer.Option(
+        False,
+        "--json",
+        help="Output JSON format.",
+    ),
+    quiet: bool = typer.Option(
+        False,
+        "--quiet",
+        "-q",
+        help="Suppress non-error output.",
+    ),
 ) -> None:
     """Transition project to a new lifecycle stage."""
     result = transition_stage(path, new_stage)
 
-    # Handle warnings that need confirmation
+    # Handle warnings that need confirmation (auto-fail in json/quiet mode)
     if result.needs_confirmation:
+        if json_output or quiet:
+            # In automation mode, don't prompt - just fail
+            if json_output:
+                typer.echo(result.model_dump_json(indent=2))
+            raise typer.Exit(1)
         typer.echo(f"⚠ {result.warning_message}", err=True)
         if not typer.confirm("Continue anyway?"):
             typer.echo("Aborted.")
@@ -129,13 +170,18 @@ def stage_cmd(
         # Re-run with force
         result = transition_stage(path, new_stage, force=True)
 
+    if json_output:
+        typer.echo(result.model_dump_json(indent=2))
+        raise typer.Exit(0 if result.success else 1)
+
     # Print issues (warnings and errors go to stderr)
     for issue in result.issues:
         icon = "✗" if issue.severity == "error" else "⚠"
         typer.echo(f"{icon} {issue.message}", err=True)
 
     if result.success:
-        typer.echo(f"✓ Stage updated to '{new_stage}'")
+        if not quiet:
+            typer.echo(f"✓ Stage updated to '{new_stage}'")
         raise typer.Exit(0)
     else:
         typer.echo("✗ Failed to update stage", err=True)
@@ -155,9 +201,28 @@ def validate_cmd(
         "-s",
         help="Treat warnings as errors (exit 1).",
     ),
+    json_output: bool = typer.Option(
+        False,
+        "--json",
+        help="Output JSON format.",
+    ),
+    quiet: bool = typer.Option(
+        False,
+        "--quiet",
+        "-q",
+        help="Suppress non-error output.",
+    ),
 ) -> None:
     """Validate a praxis.yaml configuration."""
     result = validate(path)
+
+    if json_output:
+        typer.echo(result.model_dump_json(indent=2))
+        has_failures = len(result.errors) > 0
+        has_warnings = len(result.warnings) > 0
+        if has_failures or (strict and has_warnings):
+            raise typer.Exit(1)
+        raise typer.Exit(0)
 
     # Print issues (warnings and errors go to stderr)
     for issue in result.issues:
@@ -167,7 +232,8 @@ def validate_cmd(
 
     # Print summary
     if result.valid and not result.warnings:
-        typer.echo("\u2713 praxis.yaml is valid")
+        if not quiet:
+            typer.echo("\u2713 praxis.yaml is valid")
         raise typer.Exit(0)
 
     if result.valid and result.warnings:
@@ -177,9 +243,10 @@ def validate_cmd(
                 err=True,
             )
             raise typer.Exit(1)
-        typer.echo(
-            f"\u2713 praxis.yaml is valid ({len(result.warnings)} warning(s))"
-        )
+        if not quiet:
+            typer.echo(
+                f"\u2713 praxis.yaml is valid ({len(result.warnings)} warning(s))"
+            )
         raise typer.Exit(0)
 
     # Has errors
@@ -193,9 +260,24 @@ def status_cmd(
         Path("."),
         help="Project directory.",
     ),
+    json_output: bool = typer.Option(
+        False,
+        "--json",
+        help="Output JSON format.",
+    ),
+    quiet: bool = typer.Option(
+        False,
+        "--quiet",
+        "-q",
+        help="Suppress non-error output.",
+    ),
 ) -> None:
     """Show project status including stage, validation, and history."""
     status = get_status(path)
+
+    if json_output:
+        typer.echo(status.model_dump_json(indent=2))
+        raise typer.Exit(0 if status.config else 1)
 
     # Handle config load errors
     if status.config is None:
@@ -203,6 +285,9 @@ def status_cmd(
         for err in status.errors:
             typer.echo(f"\u2717 {err}", err=True)
         raise typer.Exit(1)
+
+    if quiet:
+        raise typer.Exit(0)
 
     config = status.config
 
@@ -270,6 +355,12 @@ def audit_cmd(
         "--json",
         help="Output JSON format.",
     ),
+    quiet: bool = typer.Option(
+        False,
+        "--quiet",
+        "-q",
+        help="Suppress non-error output.",
+    ),
     strict: bool = typer.Option(
         False,
         "--strict",
@@ -280,33 +371,37 @@ def audit_cmd(
     """Check project against domain best practices."""
     result = audit_project(path)
 
-    if json_output:
-        typer.echo(result.model_dump_json(indent=2))
-    else:
-        typer.echo(f"\nAuditing: {result.project_name} (domain: {result.domain})\n")
-
-        # Group by category
-        by_category: dict[str, list[AuditCheck]] = {}
-        for check in result.checks:
-            by_category.setdefault(check.category, []).append(check)
-
-        icons = {"passed": "\u2713", "warning": "\u26a0", "failed": "\u2717"}
-        for category, checks in by_category.items():
-            typer.echo(f"{category.title()}:")
-            for check in checks:
-                typer.echo(f"  {icons[check.status]} {check.message}")
-            typer.echo("")
-
-        # Summary
-        p, w, f = len(result.passed), len(result.warnings), len(result.failed)
-        typer.echo(f"Summary: {p} passed, {w} warning(s), {f} failed")
-
-    # Exit code
+    # Exit code determination
     has_failures = len(result.failed) > 0
     has_warnings = len(result.warnings) > 0
-    if has_failures or (strict and has_warnings):
-        raise typer.Exit(1)
-    raise typer.Exit(0)
+    exit_code = 1 if has_failures or (strict and has_warnings) else 0
+
+    if json_output:
+        typer.echo(result.model_dump_json(indent=2))
+        raise typer.Exit(exit_code)
+
+    if quiet:
+        raise typer.Exit(exit_code)
+
+    typer.echo(f"\nAuditing: {result.project_name} (domain: {result.domain})\n")
+
+    # Group by category
+    by_category: dict[str, list[AuditCheck]] = {}
+    for check in result.checks:
+        by_category.setdefault(check.category, []).append(check)
+
+    icons = {"passed": "\u2713", "warning": "\u26a0", "failed": "\u2717"}
+    for category, checks in by_category.items():
+        typer.echo(f"{category.title()}:")
+        for check in checks:
+            typer.echo(f"  {icons[check.status]} {check.message}")
+        typer.echo("")
+
+    # Summary
+    p, w, f = len(result.passed), len(result.warnings), len(result.failed)
+    typer.echo(f"Summary: {p} passed, {w} warning(s), {f} failed")
+
+    raise typer.Exit(exit_code)
 
 
 if __name__ == "__main__":

--- a/tests/features/cli_automation.feature
+++ b/tests/features/cli_automation.feature
@@ -1,0 +1,75 @@
+Feature: CLI Automation Flags
+  As a developer using Praxis in CI/CD
+  I want machine-readable output and quiet mode
+  So that I can automate praxis commands
+
+  # --json flag tests
+
+  Scenario: Init with --json outputs structured JSON
+    Given an empty project directory
+    When I run praxis init --domain code --privacy personal --json
+    Then the exit code should be 0
+    And the output should be valid JSON
+    And the JSON should have key "success"
+    And the JSON should have key "files_created"
+
+  Scenario: Init --json requires --domain and --privacy
+    Given an empty project directory
+    When I run praxis init --json
+    Then the exit code should be 1
+    And the output should contain "errors"
+
+  Scenario: Validate with --json outputs structured JSON
+    Given a valid praxis project at capture stage
+    When I run praxis validate --json
+    Then the exit code should be 0
+    And the output should be valid JSON
+    And the JSON should have key "valid"
+    And the JSON should have key "config"
+
+  Scenario: Stage with --json outputs structured JSON
+    Given a valid praxis project at capture stage
+    When I run praxis stage sense --json
+    Then the exit code should be 0
+    And the output should be valid JSON
+    And the JSON should have key "success"
+
+  Scenario: Status with --json outputs structured JSON
+    Given a valid praxis project at capture stage
+    When I run praxis status --json
+    Then the exit code should be 0
+    And the output should be valid JSON
+    And the JSON should have key "project_name"
+    And the JSON should have key "config"
+
+  # --quiet flag tests
+
+  Scenario: Init with --quiet suppresses output on success
+    Given an empty project directory
+    When I run praxis init --domain code --privacy personal --quiet
+    Then the exit code should be 0
+    And the output should be empty
+
+  Scenario: Validate with --quiet suppresses output on success
+    Given a valid praxis project at capture stage
+    When I run praxis validate --quiet
+    Then the exit code should be 0
+    And the output should be empty
+
+  Scenario: Stage with --quiet suppresses success message
+    Given a valid praxis project at capture stage
+    When I run praxis stage sense --quiet
+    Then the exit code should be 0
+    And the output should be empty
+
+  Scenario: Status with --quiet suppresses output
+    Given a valid praxis project at capture stage
+    When I run praxis status --quiet
+    Then the exit code should be 0
+    And the output should be empty
+
+  Scenario: Audit with --quiet suppresses output
+    Given a valid praxis project at capture stage
+    When I run praxis audit --quiet
+    Then the exit code should be 0
+    And the output should be empty

--- a/tests/step_defs/test_cli_automation.py
+++ b/tests/step_defs/test_cli_automation.py
@@ -1,0 +1,151 @@
+"""Step definitions for cli_automation.feature."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from pytest_bdd import given, parsers, scenarios, then, when
+from typer.testing import CliRunner
+
+from praxis.cli import app
+
+scenarios("../features/cli_automation.feature")
+
+
+@given("an empty project directory")
+def empty_project_directory(tmp_path: Path, context: dict[str, Any]) -> None:
+    """Use the pytest tmp_path as an empty project directory."""
+    context["project_root"] = tmp_path
+
+
+@given("a valid praxis project at capture stage")
+def valid_praxis_project(tmp_path: Path, context: dict[str, Any]) -> None:
+    """Create a valid praxis project at capture stage."""
+    context["project_root"] = tmp_path
+    praxis_yaml = tmp_path / "praxis.yaml"
+    praxis_yaml.write_text(
+        """domain: code
+stage: capture
+privacy_level: personal
+environment: Home
+"""
+    )
+
+
+@when("I run praxis init --domain code --privacy personal --json")
+def run_init_json(cli_runner: CliRunner, context: dict[str, Any]) -> None:
+    """Run praxis init with --json flag."""
+    project_root = context["project_root"]
+    result = cli_runner.invoke(
+        app,
+        ["init", str(project_root), "--domain", "code", "--privacy", "personal", "--json"],
+    )
+    context["result"] = result
+
+
+@when("I run praxis init --json")
+def run_init_json_no_flags(cli_runner: CliRunner, context: dict[str, Any]) -> None:
+    """Run praxis init with only --json flag (missing required flags)."""
+    project_root = context["project_root"]
+    result = cli_runner.invoke(
+        app,
+        ["init", str(project_root), "--json"],
+    )
+    context["result"] = result
+
+
+@when("I run praxis init --domain code --privacy personal --quiet")
+def run_init_quiet(cli_runner: CliRunner, context: dict[str, Any]) -> None:
+    """Run praxis init with --quiet flag."""
+    project_root = context["project_root"]
+    result = cli_runner.invoke(
+        app,
+        ["init", str(project_root), "--domain", "code", "--privacy", "personal", "--quiet"],
+    )
+    context["result"] = result
+
+
+@when("I run praxis validate --json")
+def run_validate_json(cli_runner: CliRunner, context: dict[str, Any]) -> None:
+    """Run praxis validate with --json flag."""
+    project_root = context["project_root"]
+    result = cli_runner.invoke(app, ["validate", str(project_root), "--json"])
+    context["result"] = result
+
+
+@when("I run praxis validate --quiet")
+def run_validate_quiet(cli_runner: CliRunner, context: dict[str, Any]) -> None:
+    """Run praxis validate with --quiet flag."""
+    project_root = context["project_root"]
+    result = cli_runner.invoke(app, ["validate", str(project_root), "--quiet"])
+    context["result"] = result
+
+
+@when("I run praxis stage sense --json")
+def run_stage_json(cli_runner: CliRunner, context: dict[str, Any]) -> None:
+    """Run praxis stage with --json flag."""
+    project_root = context["project_root"]
+    result = cli_runner.invoke(app, ["stage", "sense", str(project_root), "--json"])
+    context["result"] = result
+
+
+@when("I run praxis stage sense --quiet")
+def run_stage_quiet(cli_runner: CliRunner, context: dict[str, Any]) -> None:
+    """Run praxis stage with --quiet flag."""
+    project_root = context["project_root"]
+    result = cli_runner.invoke(app, ["stage", "sense", str(project_root), "--quiet"])
+    context["result"] = result
+
+
+@when("I run praxis status --json")
+def run_status_json(cli_runner: CliRunner, context: dict[str, Any]) -> None:
+    """Run praxis status with --json flag."""
+    project_root = context["project_root"]
+    result = cli_runner.invoke(app, ["status", str(project_root), "--json"])
+    context["result"] = result
+
+
+@when("I run praxis status --quiet")
+def run_status_quiet(cli_runner: CliRunner, context: dict[str, Any]) -> None:
+    """Run praxis status with --quiet flag."""
+    project_root = context["project_root"]
+    result = cli_runner.invoke(app, ["status", str(project_root), "--quiet"])
+    context["result"] = result
+
+
+@when("I run praxis audit --quiet")
+def run_audit_quiet(cli_runner: CliRunner, context: dict[str, Any]) -> None:
+    """Run praxis audit with --quiet flag."""
+    project_root = context["project_root"]
+    result = cli_runner.invoke(app, ["audit", str(project_root), "--quiet"])
+    context["result"] = result
+
+
+@then("the output should be valid JSON")
+def check_valid_json(context: dict[str, Any]) -> None:
+    """Verify the output is valid JSON."""
+    result = context["result"]
+    try:
+        context["json_output"] = json.loads(result.output)
+    except json.JSONDecodeError as e:
+        raise AssertionError(f"Output is not valid JSON: {e}\nOutput: {result.output}")
+
+
+@then(parsers.parse('the JSON should have key "{key}"'))
+def check_json_has_key(context: dict[str, Any], key: str) -> None:
+    """Verify the JSON output has a specific key."""
+    json_output = context.get("json_output")
+    if json_output is None:
+        # Parse if not already parsed
+        result = context["result"]
+        json_output = json.loads(result.output)
+    assert key in json_output, f"Expected key '{key}' in JSON. Got keys: {list(json_output.keys())}"
+
+
+@then("the output should be empty")
+def check_output_empty(context: dict[str, Any]) -> None:
+    """Verify the output is empty (or only whitespace)."""
+    result = context["result"]
+    assert result.output.strip() == "", f"Expected empty output, got: {result.output}"


### PR DESCRIPTION
## Summary

- Add `--quiet` and `--json` flags to all CLI commands for CI/CD integration
- Convert `status_service.py` to use Pydantic models for JSON serialization
- Add 10 BDD tests for the new flags

## Changes by Command

| Command | `--json` | `--quiet` |
|---------|----------|-----------|
| init | ✅ outputs `InitResult` | ✅ suppresses success output |
| validate | ✅ outputs `ValidationResult` | ✅ suppresses success output |
| stage | ✅ outputs `StageResult` | ✅ suppresses success output |
| status | ✅ outputs `ProjectStatus` | ✅ suppresses all output |
| audit | ✅ (already existed) | ✅ added |

## Behavior Notes

- `--json` with `init` requires `--domain` and `--privacy` (no interactive prompts)
- `--quiet`/`--json` with `stage` auto-fails if confirmation needed (no prompts)
- Exit codes still reflect success/failure regardless of output mode

## Test plan

- [x] All 79 tests pass (10 new BDD tests for automation flags)
- [x] ruff check passes
- [x] Manual testing of each flag combination

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)