### PR TITLE
feat: add validation hooks to praxis validate (#53)

### DIFF
--- a/src/praxis/domain/models.py
+++ b/src/praxis/domain/models.py
@@ -63,6 +63,15 @@ class StageResult(BaseModel):
     warning_message: str | None = None
 
 
+class ToolCheckResult(BaseModel):
+    """Result of running an external validation tool."""
+
+    tool: str
+    success: bool
+    output: str = ""
+    error: str = ""
+
+
 class AuditCheck(BaseModel):
     """Single audit check result."""
 

--- a/src/praxis/infrastructure/tool_runner.py
+++ b/src/praxis/infrastructure/tool_runner.py
@@ -1,0 +1,153 @@
+"""Tool runner - executes external validation tools (pytest, ruff, mypy)."""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass
+class ToolResult:
+    """Result of running an external tool."""
+
+    tool: str
+    success: bool
+    output: str
+    error: str
+    return_code: int
+
+
+def run_tool(
+    command: list[str],
+    tool_name: str,
+    cwd: Path,
+    timeout: int = 300,
+) -> ToolResult:
+    """Run an external tool and capture its output.
+
+    Args:
+        command: Command and arguments to run.
+        tool_name: Human-readable tool name for reporting.
+        cwd: Working directory to run the command in.
+        timeout: Maximum seconds to wait (default 5 minutes).
+
+    Returns:
+        ToolResult with success status and output.
+    """
+    try:
+        result = subprocess.run(
+            command,
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+        return ToolResult(
+            tool=tool_name,
+            success=result.returncode == 0,
+            output=result.stdout,
+            error=result.stderr,
+            return_code=result.returncode,
+        )
+    except subprocess.TimeoutExpired:
+        return ToolResult(
+            tool=tool_name,
+            success=False,
+            output="",
+            error=f"{tool_name} timed out after {timeout} seconds",
+            return_code=-1,
+        )
+    except FileNotFoundError:
+        return ToolResult(
+            tool=tool_name,
+            success=False,
+            output="",
+            error=f"{tool_name} not found. Is it installed?",
+            return_code=-1,
+        )
+
+
+def run_pytest(project_root: Path) -> ToolResult:
+    """Run pytest in the project directory.
+
+    Args:
+        project_root: Project directory containing tests.
+
+    Returns:
+        ToolResult indicating if tests passed.
+    """
+    # Try poetry run pytest first, fall back to pytest
+    commands = [
+        ["poetry", "run", "pytest", "--tb=short", "-q"],
+        ["pytest", "--tb=short", "-q"],
+    ]
+
+    for cmd in commands:
+        result = run_tool(cmd, "pytest", project_root)
+        if result.return_code != -1:  # Tool was found
+            return result
+
+    return ToolResult(
+        tool="pytest",
+        success=False,
+        output="",
+        error="pytest not found. Install with: pip install pytest",
+        return_code=-1,
+    )
+
+
+def run_ruff(project_root: Path) -> ToolResult:
+    """Run ruff linter in the project directory.
+
+    Args:
+        project_root: Project directory to lint.
+
+    Returns:
+        ToolResult indicating if linting passed.
+    """
+    commands = [
+        ["poetry", "run", "ruff", "check", "."],
+        ["ruff", "check", "."],
+    ]
+
+    for cmd in commands:
+        result = run_tool(cmd, "ruff", project_root)
+        if result.return_code != -1:
+            return result
+
+    return ToolResult(
+        tool="ruff",
+        success=False,
+        output="",
+        error="ruff not found. Install with: pip install ruff",
+        return_code=-1,
+    )
+
+
+def run_mypy(project_root: Path) -> ToolResult:
+    """Run mypy type checker in the project directory.
+
+    Args:
+        project_root: Project directory to type check.
+
+    Returns:
+        ToolResult indicating if type checking passed.
+    """
+    commands = [
+        ["poetry", "run", "mypy", "."],
+        ["mypy", "."],
+    ]
+
+    for cmd in commands:
+        result = run_tool(cmd, "mypy", project_root)
+        if result.return_code != -1:
+            return result
+
+    return ToolResult(
+        tool="mypy",
+        success=False,
+        output="",
+        error="mypy not found. Install with: pip install mypy",
+        return_code=-1,
+    )

--- a/tests/features/validate.feature
+++ b/tests/features/validate.feature
@@ -8,7 +8,7 @@ Feature: Praxis Validate CLI
     And a docs/sod.md file exists
     When I run praxis validate
     Then the exit code should be 0
-    And the output should contain "valid"
+    And the output should contain "passed"
 
   Scenario: Missing SOD at Execute stage fails
     Given a project with domain "code" and stage "execute"
@@ -23,7 +23,7 @@ Feature: Praxis Validate CLI
     And no docs/sod.md file exists
     When I run praxis validate
     Then the exit code should be 0
-    And the output should contain "valid"
+    And the output should contain "passed"
 
   Scenario: Invalid domain rejected
     Given a project with domain "invalid_domain" and stage "explore"
@@ -36,3 +36,28 @@ Feature: Praxis Validate CLI
     When I run praxis validate
     Then the exit code should be 1
     And the output should contain "ERROR"
+
+  Scenario: Check-all flag runs all tool checks
+    Given a valid project with passing tests
+    When I run praxis validate --check-all
+    Then the exit code should be 0
+    And the output should contain "Tool Checks"
+    And the output should contain "pytest"
+
+  Scenario: Check-tests flag runs pytest
+    Given a valid project with passing tests
+    When I run praxis validate --check-tests
+    Then the exit code should be 0
+    And the output should contain "pytest"
+
+  Scenario: Check-lint flag runs ruff
+    Given a valid project with passing tests
+    When I run praxis validate --check-lint
+    Then the exit code should be 0
+    And the output should contain "ruff"
+
+  Scenario: Check-types flag runs mypy
+    Given a valid project with passing tests
+    When I run praxis validate --check-types
+    Then the exit code should be 0
+    And the output should contain "mypy"

--- a/tests/step_defs/test_validate.py
+++ b/tests/step_defs/test_validate.py
@@ -51,6 +51,66 @@ def ensure_no_sod(context: dict[str, Any]) -> None:
         sod_path.unlink()
 
 
+@given("a valid project with passing tests")
+def create_valid_project_with_tests(
+    tmp_path: Path,
+    context: dict[str, Any],
+) -> None:
+    """Create a valid project with passing tests, lint, and types."""
+    context["project_root"] = tmp_path
+
+    # Create praxis.yaml
+    praxis_yaml = tmp_path / "praxis.yaml"
+    praxis_yaml.write_text(
+        """domain: code
+stage: explore
+privacy_level: personal
+environment: Home
+"""
+    )
+
+    # Create pyproject.toml for poetry
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        """[tool.poetry]
+name = "test-project"
+version = "0.1.0"
+description = "Test"
+authors = ["Test <test@test.com>"]
+
+[tool.poetry.dependencies]
+python = "^3.11"
+
+[tool.ruff]
+line-length = 88
+
+[tool.mypy]
+python_version = "3.11"
+files = ["src"]
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"
+"""
+    )
+
+    # Create a simple passing test
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+    test_file = tests_dir / "test_example.py"
+    test_file.write_text(
+        """def test_example():
+    assert True
+"""
+    )
+
+    # Create src directory for mypy
+    src_dir = tmp_path / "src"
+    src_dir.mkdir()
+    init_file = src_dir / "__init__.py"
+    init_file.write_text("")
+
+
 @when("I run praxis validate")
 def run_validate(
     cli_runner: CliRunner,
@@ -59,6 +119,19 @@ def run_validate(
     """Run the praxis validate command."""
     project_root = context["project_root"]
     result = cli_runner.invoke(app, ["validate", str(project_root)])
+    context["result"] = result
+
+
+@when(parsers.parse("I run praxis validate {flags}"))
+def run_validate_with_flags(
+    cli_runner: CliRunner,
+    context: dict[str, Any],
+    flags: str,
+) -> None:
+    """Run the praxis validate command with flags."""
+    project_root = context["project_root"]
+    args = ["validate", str(project_root)] + flags.split()
+    result = cli_runner.invoke(app, args)
     context["result"] = result
 
 


### PR DESCRIPTION
## Summary
- Add `--check-tests` flag to run pytest during validation
- Add `--check-lint` flag to run ruff during validation
- Add `--check-types` flag to run mypy during validation
- Add `--check-all` flag to run all tool checks

## Changes
- `src/praxis/infrastructure/tool_runner.py` (NEW) - Runs external validation tools
- `src/praxis/domain/models.py` - Added ToolCheckResult model
- `src/praxis/cli.py` - Added validation flags
- `tests/features/validate.feature` - Added 4 BDD scenarios
- `tests/step_defs/test_validate.py` - Added step definitions

## Test plan
- [x] All 83 tests pass
- [x] `praxis validate --check-tests` runs pytest
- [x] `praxis validate --check-lint` runs ruff
- [x] `praxis validate --check-types` runs mypy
- [x] `praxis validate --check-all` runs all checks

Fixes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)