### PR TITLE
docs: finalize ADR-001 and ADR-002 (#7)

### DIFF
--- a/docs/adr/001-policy-engine.md
+++ b/docs/adr/001-policy-engine.md
@@ -1,8 +1,8 @@
 # ADR-001: Policy Engine Selection
 
-**Status:** Exploratory
-**Date:** 2025-12-21
-**Deciders:** TBD
+**Status:** Accepted
+**Date:** 2025-12-21 (Draft), 2025-12-28 (Accepted)
+**Deciders:** @jayers99
 
 ---
 
@@ -28,6 +28,7 @@ This is a foundational choice that affects all downstream tooling.
 - **Ecosystem** — Tooling, docs, community support
 - **Portability** — Not locked to a specific runtime or platform
 - **Learning curve** — Acceptable for a solo author / small team
+- **Pragmatism** — Start simple, evolve as needed
 
 ---
 
@@ -42,9 +43,9 @@ This is a foundational choice that affects all downstream tooling.
 | Strong composition via unification | Smaller ecosystem than alternatives |
 | Types and constraints in one language | Learning curve for unification model |
 | Can validate AND generate configs | Less tooling than JSON Schema |
-| Good fit for "dimensions compose" model | |
+| Good fit for "dimensions compose" model | Additional runtime dependency |
 
-**Fit for Praxis:** High — unification model maps well to "domain + stage + privacy = behavior"
+**Fit for Praxis:** Medium — powerful but adds complexity not yet needed
 
 ### Option 2: JSON Schema + Custom Validator
 
@@ -85,68 +86,95 @@ This is a foundational choice that affects all downstream tooling.
 
 **Fit for Praxis:** Low — premature optimization
 
-### Option 5: Python with Pydantic
+### Option 5: Python with Pydantic (CHOSEN)
 
 **Description:** Use Python dataclasses/Pydantic for schema, custom validators for rules.
 
 | Pros | Cons |
 | --- | --- |
 | Familiar to Python developers | Policy mixed with implementation |
-| Strong typing with Pydantic | Less declarative |
-| Easy to start | Harder to audit/review policies |
-| Good test tooling | |
+| Strong typing with Pydantic v2 | Less declarative than CUE |
+| Easy to start and iterate | Harder to audit/review policies separately |
+| Excellent test tooling | |
+| No additional runtime | |
+| Rich validation with clear errors | |
 
-**Fit for Praxis:** Medium — pragmatic starting point, may outgrow
-
----
-
-## Current Recommendation
-
-**CUE** is the leading candidate due to:
-
-1. Unification model matches Praxis's compositional dimensions
-2. Single language for schema + validation + generation
-3. Declarative and auditable
-4. Reasonable learning investment for the value
-
-However, this remains **exploratory** until validated by the first executable increment.
-
----
-
-## Validation Plan
-
-1. Implement minimal schema for Code domain in CUE
-2. Write 3-5 test cases (valid configs, invalid transitions, privacy violations)
-3. Evaluate friction: Is CUE helping or hindering?
-4. If CUE proves wrong, fall back to Pydantic (Option 5) as pragmatic alternative
+**Fit for Praxis:** High — pragmatic, well-supported, proven effective
 
 ---
 
 ## Decision
 
-**Deferred** — Will be finalized after first increment validation.
+**Python with Pydantic (Option 5)** is selected as the policy engine.
+
+### Rationale
+
+After implementing the validation model through worked projects (Issue #4, uat-praxis-code), Pydantic proved to be the right choice:
+
+1. **Sufficient for current needs** — Pydantic handles schema validation, custom validators, and clear error messages effectively
+2. **No additional learning curve** — Python developers can contribute immediately
+3. **Fast iteration** — Easy to add new rules and modify existing ones
+4. **Strong typing** — Pydantic v2 provides excellent type inference and validation
+5. **Ecosystem integration** — Works seamlessly with Typer CLI and Python tooling
+
+### Why not CUE?
+
+CUE remains interesting for future consideration but was deferred because:
+
+- Adds a runtime dependency and learning curve
+- Current validation needs are well-served by Pydantic
+- The "unification model" benefits aren't realized until we have more complex policy composition
+- Pragmatism favors starting simple
+
+CUE may be reconsidered if:
+- Multi-domain projects require complex policy composition
+- Policy definition needs to be externalized for non-developers
+- Cross-language policy sharing becomes important
+
+---
+
+## Implementation Details
+
+The current implementation uses:
+
+- **Pydantic BaseModel** for `PraxisConfig` schema
+- **Pydantic validators** for field-level validation
+- **Custom service layer** for cross-field rules (artifact checks, regression detection)
+- **Infrastructure layer** for git integration and file system checks
+
+Key files:
+- `src/praxis/domain/models.py` — Pydantic models
+- `src/praxis/application/validate_service.py` — Validation orchestration
+- `src/praxis/infrastructure/` — Git, filesystem, YAML adapters
 
 ---
 
 ## Consequences
 
-### If CUE is adopted
+### Enables
 
-- Must learn CUE syntax and unification model
-- Policy files are `.cue`, versioned alongside code
-- CLI tooling depends on CUE runtime
+- Fast development with familiar tooling
+- Easy testing with pytest
+- Clear error messages from Pydantic
+- No external runtime dependencies
+- Simple deployment (pure Python)
 
-### If CUE is rejected
+### Limits
 
-- Fall back to Pydantic + custom validators
-- Policy lives in Python code
-- Less separation between policy and implementation
+- Policy is code (not a separate declarative layer)
+- Harder for non-developers to modify rules
+- No built-in policy composition primitives
+
+### Deferred
+
+- CUE exploration for complex multi-domain scenarios
+- Externalized policy definition
+- Policy-as-data format
 
 ---
 
 ## Related
 
-- SOD v0.3 Section 7 (Policy Enforcement)
-- GitHub Issue: Policy engine exploration spike
-
----
+- ADR-002 (Validation Model) — Defines what the policy engine validates
+- Issue #4 (template-python-cli) — First worked project validating this choice
+- Issue #7 — ADR finalization


### PR DESCRIPTION
## Summary
Finalizes both ADRs based on learnings from the template-python-cli worked project.

### ADR-001: Policy Engine Selection
- **Status:** Exploratory → Accepted
- **Decision:** Pydantic chosen over CUE
- Pragmatic choice that's proven effective through real implementation
- CUE remains as future option if complexity grows

### ADR-002: Validation Model
- **Status:** Draft → Accepted
- All open questions resolved with rationale:
  - Manual stage tracking: Natural, not burdensome
  - `docs/sod.md` convention: Works, no configurability needed
  - Minimum validation: Schema + artifact + warnings is right-sized
  - Integration: Manual by default, `--check-*` flags for CI

## Test plan
- [x] All 83 tests pass
- [x] ADRs are internally consistent
- [x] Cross-references between ADRs updated

Fixes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)