### PR TITLE
feat: add coverage threshold enforcement (#54)

### DIFF
--- a/src/praxis/domain/models.py
+++ b/src/praxis/domain/models.py
@@ -18,6 +18,12 @@ class PraxisConfig(BaseModel):
     stage: Stage
     privacy_level: PrivacyLevel
     environment: str = Field(default="Home", pattern=r"^(Home|Work)$")
+    coverage_threshold: int | None = Field(
+        default=None,
+        ge=0,
+        le=100,
+        description="Minimum test coverage percentage (0-100). Optional.",
+    )
 
 
 class ValidationIssue(BaseModel):
@@ -69,6 +75,16 @@ class ToolCheckResult(BaseModel):
     tool: str
     success: bool
     output: str = ""
+    error: str = ""
+
+
+class CoverageCheckResult(BaseModel):
+    """Result of running coverage check."""
+
+    tool: str = "coverage"
+    success: bool
+    coverage_percent: float | None = None
+    threshold: int
     error: str = ""
 
 

--- a/tests/features/validate.feature
+++ b/tests/features/validate.feature
@@ -61,3 +61,20 @@ Feature: Praxis Validate CLI
     When I run praxis validate --check-types
     Then the exit code should be 0
     And the output should contain "mypy"
+
+  Scenario: Check-coverage without threshold configured fails
+    Given a project with domain "code" and stage "execute"
+    And a docs/sod.md file exists
+    When I run praxis validate --check-coverage
+    Then the exit code should be 1
+    And the output should contain "coverage_threshold not set"
+
+  Scenario: Check-coverage with threshold configured attempts coverage
+    Given a valid project with coverage threshold 50
+    When I run praxis validate --check-coverage
+    Then the output should contain "coverage"
+
+  Scenario: Check-all includes coverage when threshold configured
+    Given a valid project with coverage threshold 50
+    When I run praxis validate --check-all
+    Then the output should contain "coverage"

--- a/tests/step_defs/test_validate.py
+++ b/tests/step_defs/test_validate.py
@@ -111,6 +111,81 @@ build-backend = "poetry.core.masonry.api"
     init_file.write_text("")
 
 
+@given(parsers.parse("a valid project with coverage threshold {threshold:d}"))
+def create_valid_project_with_coverage(
+    tmp_path: Path,
+    context: dict[str, Any],
+    threshold: int,
+) -> None:
+    """Create a valid project with coverage threshold configured."""
+    context["project_root"] = tmp_path
+
+    # Create praxis.yaml with coverage_threshold
+    praxis_yaml = tmp_path / "praxis.yaml"
+    praxis_yaml.write_text(
+        f"""domain: code
+stage: explore
+privacy_level: personal
+environment: Home
+coverage_threshold: {threshold}
+"""
+    )
+
+    # Create pyproject.toml for poetry
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        """[tool.poetry]
+name = "test-project"
+version = "0.1.0"
+description = "Test"
+authors = ["Test <test@test.com>"]
+
+[tool.poetry.dependencies]
+python = "^3.11"
+
+[tool.poetry.group.dev.dependencies]
+pytest = "^8.0"
+pytest-cov = "^4.0"
+
+[tool.ruff]
+line-length = 88
+
+[tool.mypy]
+python_version = "3.11"
+files = ["src"]
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"
+"""
+    )
+
+    # Create a simple module with a function
+    src_dir = tmp_path / "src"
+    src_dir.mkdir()
+    init_file = src_dir / "__init__.py"
+    init_file.write_text("")
+
+    module_file = src_dir / "example.py"
+    module_file.write_text(
+        """def add(a: int, b: int) -> int:
+    return a + b
+"""
+    )
+
+    # Create a test that covers the function
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+    test_file = tests_dir / "test_example.py"
+    test_file.write_text(
+        """from src.example import add
+
+def test_add():
+    assert add(1, 2) == 3
+"""
+    )
+
+
 @when("I run praxis validate")
 def run_validate(
     cli_runner: CliRunner,


### PR DESCRIPTION
## Summary
Adds optional `coverage_threshold` field to `praxis.yaml` that enables coverage checking during validation.

## Changes
- `src/praxis/domain/models.py` - Add `coverage_threshold` (0-100) to PraxisConfig, add CoverageCheckResult model
- `src/praxis/infrastructure/tool_runner.py` - Add CoverageResult dataclass and run_coverage function
- `src/praxis/cli.py` - Add `--check-coverage` flag, include coverage in `--check-all`
- `tests/features/validate.feature` - Add 3 BDD scenarios
- `tests/step_defs/test_validate.py` - Add step definition for coverage threshold

## Usage

```yaml
# praxis.yaml
domain: code
stage: execute
privacy_level: personal
coverage_threshold: 80  # Optional: require 80% coverage
```

```bash
# Check coverage against threshold
praxis validate --check-coverage

# Includes coverage if threshold configured
praxis validate --check-all
```

## Test plan
- [x] All 86 tests pass
- [x] ruff linting passes on modified files
- [x] mypy type checking passes on modified files
- [x] `--check-coverage` fails gracefully when threshold not configured
- [x] `--check-coverage` attempts coverage check when threshold is set

Fixes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)