### PR TITLE
Spike Research: SOD Template, Sustain, Regression Detection, Shape Up (#76-79)

### DIFF
--- a/projects/write/opinions-framework/docs/01-refine-lifecycle-research-02-sod-template-report.md
+++ b/projects/write/opinions-framework/docs/01-refine-lifecycle-research-02-sod-template-report.md
@@ -1,0 +1,139 @@
+# Spike Report: SOD Template Research
+
+**Project:** opinions-framework
+**Spike:** #76 - SOD Template Research
+**Date:** 2025-12-28
+**Status:** Complete
+
+---
+
+## Executive Summary
+
+Researched Solution Overview Documents (SOD) and compared them to PRDs, BRDs, RFCs, and Design Docs. Found that SOD is not a standardized industry term—Praxis can define it as a lightweight formalization artifact that combines the best elements of existing document types while staying minimal.
+
+---
+
+## Comparison Matrix
+
+| Document Type | Audience | Focus | Typical Length | When Used |
+|---------------|----------|-------|----------------|-----------|
+| **BRD** (Business Requirements) | Executives, stakeholders | Business case, goals, constraints | 5-15 pages | Before funding approval |
+| **PRD** (Product Requirements) | Product, Engineering, Design | What to build, user stories, success metrics | 3-10 pages | Before development |
+| **RFC** (Request for Comments) | Engineering peers | Technical approach, tradeoffs, alternatives | 2-8 pages | Before implementation |
+| **Design Doc** | Engineering team | How to build, architecture, APIs | 5-15 pages | During implementation planning |
+| **SOD** (Praxis) | Self + collaborators | Solution boundaries, constraints, done criteria | 1-3 pages | At Formalize stage |
+
+### Key Insight
+
+PRDs describe "a problem that needs to be solved" while RFCs describe "a solution you'd like feedback on." The SOD should bridge both: it documents the *bounded solution* that was shaped, not the full problem space or implementation details.
+
+---
+
+## What Makes a Good SOD?
+
+Based on research into what makes effective documentation:
+
+### 1. Background/Context (Required)
+From HashiCorp's RFC template: "As a newcomer to this project, can I read the background section and get full context on why this change is necessary?"
+
+### 2. Bounded Scope (Required)
+Shape Up's pitch format includes "Appetite"—how much time/effort is worth spending. The SOD should define what's *in* and *out* explicitly.
+
+### 3. Solution Sketch (Required)
+Concrete enough to act on, abstract enough to allow flexibility. Not pixel-perfect designs, but key elements.
+
+### 4. Rabbit Holes & No-Gos (Required)
+From Shape Up: explicitly call out traps to avoid and things that are specifically excluded.
+
+### 5. Done Criteria (Required)
+How do we know when this is finished? What does success look like?
+
+---
+
+## Minimum Viable SOD
+
+Based on the research, here's the proposed minimum viable SOD structure:
+
+```markdown
+# Solution Overview: [Name]
+
+## Background
+Why are we doing this? What problem does it solve?
+
+## Appetite
+How much effort is appropriate? (Small/Medium/Large or time-boxed)
+
+## Solution
+What are we building? Key elements only—not implementation details.
+
+## Boundaries
+### In Scope
+- What's included
+
+### Out of Scope
+- What's explicitly excluded
+
+### Rabbit Holes
+- Known traps to avoid
+
+## Done Criteria
+- [ ] Criterion 1
+- [ ] Criterion 2
+```
+
+### Design Decisions
+
+1. **One page preferred, two max.** If it's longer, the scope is probably too big.
+2. **No implementation details.** That's what Design Docs and code are for.
+3. **Explicit exclusions.** "Out of Scope" and "Rabbit Holes" prevent scope creep.
+4. **Checkable done criteria.** Binary yes/no, not fuzzy goals.
+
+---
+
+## Comparison to Shape Up Pitch
+
+The SOD is very similar to a Shape Up pitch:
+
+| Shape Up Pitch | Praxis SOD |
+|----------------|------------|
+| Problem | Background |
+| Appetite | Appetite |
+| Solution | Solution |
+| Rabbit Holes | Boundaries: Rabbit Holes |
+| No-gos | Boundaries: Out of Scope |
+| (implicit) | Done Criteria |
+
+The main addition is explicit **Done Criteria**, which Shape Up handles through fixed time boxes rather than explicit acceptance criteria.
+
+---
+
+## Required vs Optional Sections
+
+| Section | Status | Rationale |
+|---------|--------|-----------|
+| Background | Required | Establishes "why" |
+| Appetite | Required | Prevents gold-plating |
+| Solution | Required | Describes "what" |
+| In Scope | Required | Clarifies boundaries |
+| Out of Scope | Required | Prevents scope creep |
+| Rabbit Holes | Optional | Not all projects have known traps |
+| Done Criteria | Required | Enables objective completion |
+| Alternatives Considered | Optional | Useful for controversial decisions |
+
+---
+
+## Sources
+
+- [Companies Using RFCs or Design Docs - The Pragmatic Engineer](https://blog.pragmaticengineer.com/rfcs-and-design-docs/)
+- [HashiCorp RFC Template](https://works.hashicorp.com/articles/rfc-template)
+- [What is a Product Requirements Document - Atlassian](https://www.atlassian.com/agile/product-management/requirements)
+- [Write the Pitch - Shape Up](https://basecamp.com/shapeup/1.5-chapter-06)
+- [6 Requirements Specification Formats - Aqua Cloud](https://aqua-cloud.io/requirements-specification-formats-brd-frd-urs/)
+
+---
+
+## Follow-Up Recommendations
+
+1. **Create SOD template file** in `docs/templates/sod.md`
+2. **Update lifecycle.md** to reference SOD template
+3. **Add SOD validation** to `praxis validate` (check required sections exist)

--- a/projects/write/opinions-framework/docs/01-refine-lifecycle-research-03-sustain-non-code-report.md
+++ b/projects/write/opinions-framework/docs/01-refine-lifecycle-research-03-sustain-non-code-report.md
@@ -1,0 +1,169 @@
+# Spike Report: Sustain for Non-Code Domains
+
+**Project:** opinions-framework
+**Spike:** #77 - Sustain for Non-Code Domains
+**Date:** 2025-12-28
+**Status:** Complete
+
+---
+
+## Executive Summary
+
+Researched what "sustain" means for non-Code domains (Create, Write, Learn, Observe). Found distinct patterns for each domain, with the common thread being: **maintenance activities that preserve value over time without fundamentally changing the work.**
+
+---
+
+## Domain-Specific Sustain Definitions
+
+### Create Domain (Art, Music, Video)
+
+**Definition:** Sustain = keeping creative work accessible, attributed, and (optionally) commercially viable.
+
+**Key Activities:**
+1. **Portfolio maintenance** - Curating which works represent current skill level
+2. **Format preservation** - Ensuring files remain playable/viewable (codec updates, format migrations)
+3. **Rights management** - Maintaining copyright, licensing, attribution
+4. **Distribution health** - Keeping links alive, platforms updated
+
+**Sources:**
+- [Managing the Life Cycle of Art - Hippo Reads](https://hipporeads.com/from-inspiration-to-preservation-managing-the-life-cycle-of-art/)
+- [Professional Self-Structuration in the Arts - MDPI](https://www.mdpi.com/2071-1050/9/6/1035)
+
+**Key Insight:** Creative work has a "decay" problem—file formats become obsolete, platforms disappear, portfolios become stale. Sustain is about fighting entropy.
+
+---
+
+### Write Domain (Docs, Essays, Specs)
+
+**Definition:** Sustain = keeping written content accurate, discoverable, and versioned.
+
+**Key Activities:**
+1. **Version control** - Tracking changes, maintaining history
+2. **Accuracy reviews** - Periodic checks for outdated information
+3. **Link maintenance** - Fixing broken references
+4. **Discoverability** - Ensuring proper indexing and navigation
+
+**Sources:**
+- [Revising and Maintaining Documentation - Digital Preservation Coalition](https://www.dpconline.org/digipres/implement-digipres/digital-preservation-documentation-guide/digital-preservation-documentation-revising)
+- [Document Lifecycle Management - Technical Writer HQ](https://technicalwriterhq.com/documentation/document-lifecycle-management/)
+
+**Best Practices from Research:**
+- Use version numbering (major.minor.patch)
+- Schedule regular review cycles (quarterly/annually)
+- Track document owners and expiration dates
+- Maintain audit trails for compliance
+
+**Key Insight:** Documents without scheduled reviews become "write-only"—created but never maintained. Sustain requires explicit review triggers.
+
+---
+
+### Learn Domain (Skills, Knowledge)
+
+**Definition:** Sustain = preventing skill decay through spaced repetition and deliberate practice.
+
+**Key Activities:**
+1. **Spaced repetition** - Reviewing knowledge at optimal intervals
+2. **Deliberate practice** - Targeted exercises to maintain proficiency
+3. **Skill inventory** - Tracking what needs maintenance vs. what can decay
+4. **Refresh cycles** - Re-engaging with material before forgetting
+
+**Sources:**
+- [Spaced Repetition for Efficient Learning - Gwern.net](https://gwern.net/spaced-repetition)
+- [Cognitive Science of Learning - Justin Skycak](https://www.justinmath.com/cognitive-science-of-learning-spaced-repetition/)
+
+**Key Research Findings:**
+- Memory follows a forgetting curve—without review, knowledge decays exponentially
+- Spaced repetition is for *maintenance*, not improvement: "If one is a gifted amateur when one starts reviewing, one remains a gifted amateur"
+- Rule of thumb: "If you'll spend more than 5 minutes looking something up over your lifetime, it's worth memorizing with spaced repetition"
+- Deliberate practice (not just repetition) is required for skill *improvement*
+
+**Key Insight:** Learn domain has the most mature science behind Sustain—spaced repetition systems (Anki, etc.) are explicitly designed for this. Praxis could integrate with SRS tools.
+
+---
+
+### Observe Domain (Notes, Bookmarks)
+
+**Definition:** Sustain = curating and pruning captured information to maintain signal-to-noise ratio.
+
+**Key Activities:**
+1. **Curation** - Deciding what's still valuable vs. noise
+2. **Organization** - Maintaining structure and findability
+3. **Link checking** - Ensuring bookmarked resources still exist
+4. **Archival decisions** - Moving to cold storage vs. deletion
+
+**Sources:**
+- [Personal Knowledge Management practices](https://gwern.net/spaced-repetition) (PKM literature)
+- Creative portfolio maintenance patterns apply here too
+
+**Key Insight:** Observe is the lowest-commitment domain for Sustain. Captured observations may intentionally be allowed to decay if they're not worth maintaining. The Sustain decision is: "Is this still worth keeping?"
+
+---
+
+## Sustain Pattern Comparison
+
+| Domain | Decay Type | Sustain Trigger | Primary Tool |
+|--------|------------|-----------------|--------------|
+| Code | Bit rot, dependencies | CI failures, security alerts | Automated tests |
+| Create | Format obsolescence, platform death | Scheduled review | Portfolio audit |
+| Write | Accuracy decay, link rot | Calendar trigger | Review cycle |
+| Learn | Forgetting curve | SRS algorithm | Spaced repetition |
+| Observe | Signal decay | Manual curation | Archive/delete review |
+
+---
+
+## Common Principles Across Domains
+
+1. **Scheduled triggers beat ad-hoc reviews.** Without explicit triggers, Sustain doesn't happen.
+
+2. **Sustain ≠ Improvement.** Sustain maintains current state; improvement requires returning to earlier stages (Formalize or Execute).
+
+3. **Not everything deserves Sustain.** Some work is intentionally allowed to Close after Execute. Sustain is a choice, not a default.
+
+4. **Automation varies by domain.** Code has the best automation (tests, CI). Learn has good tooling (SRS). Create/Write/Observe are more manual.
+
+---
+
+## Proposed Sustain Definitions for Praxis
+
+```yaml
+sustain_definitions:
+  code:
+    description: "Keeping software running, secure, and maintainable"
+    triggers: ["test failures", "security alerts", "dependency updates"]
+
+  create:
+    description: "Keeping creative work accessible and properly attributed"
+    triggers: ["scheduled portfolio review", "format obsolescence", "platform changes"]
+
+  write:
+    description: "Keeping content accurate, discoverable, and versioned"
+    triggers: ["scheduled review cycle", "broken links", "accuracy complaints"]
+
+  learn:
+    description: "Preventing skill/knowledge decay through deliberate review"
+    triggers: ["spaced repetition schedule", "skill not used recently"]
+
+  observe:
+    description: "Curating captured information to maintain value"
+    triggers: ["scheduled curation", "storage limits", "explicit review request"]
+```
+
+---
+
+## Sources
+
+- [Spaced Repetition for Efficient Learning - Gwern.net](https://gwern.net/spaced-repetition)
+- [Managing the Life Cycle of Art - Hippo Reads](https://hipporeads.com/from-inspiration-to-preservation-managing-the-life-cycle-of-art/)
+- [Revising and Maintaining Documentation - DPC](https://www.dpconline.org/digipres/implement-digipres/digital-preservation-documentation-guide/digital-preservation-documentation-revising)
+- [Document Lifecycle Management - Technical Writer HQ](https://technicalwriterhq.com/documentation/document-lifecycle-management/)
+- [Professional Self-Structuration in the Arts - MDPI](https://www.mdpi.com/2071-1050/9/6/1035)
+- [Cognitive Science of Learning - Justin Skycak](https://www.justinmath.com/cognitive-science-of-learning-spaced-repetition/)
+
+---
+
+## Follow-Up Recommendations
+
+1. **Add domain-specific sustain guidance** to `docs/domains.md`
+2. **Consider SRS integration** for Learn domain (Anki, RemNote, etc.)
+3. **Define sustain triggers** as part of `praxis.yaml` schema
+4. **Add `praxis sustain` command** to show what needs review per domain

--- a/projects/write/opinions-framework/docs/01-refine-lifecycle-research-04-regression-detection-report.md
+++ b/projects/write/opinions-framework/docs/01-refine-lifecycle-research-04-regression-detection-report.md
@@ -1,0 +1,229 @@
+# Spike Report: Regression Trigger Detection
+
+**Project:** opinions-framework
+**Spike:** #78 - Regression Trigger Detection
+**Date:** 2025-12-28
+**Status:** Complete
+
+---
+
+## Executive Summary
+
+Researched whether stage regressions can be detected automatically. Found that partial automation is feasible, particularly for Code domain scope creep detection. Other domains require more human judgment, but heuristics can raise alerts for manual review.
+
+---
+
+## Regression Triggers Identified
+
+### 1. Scope Expansion During Execute
+
+**Signal:** New work items added without removing equivalent work.
+
+**Detection Method:**
+- Track issue/story count at Formalize → Execute transition
+- Alert if net new items added during Execute
+- Burndown charts showing scope increase
+
+**Automation Feasibility:** High (can be automated via issue tracker APIs)
+
+---
+
+### 2. Requirements Drift
+
+**Signal:** Acceptance criteria modified after Formalize.
+
+**Detection Method:**
+- Snapshot SOD/acceptance criteria at stage transition
+- Diff on any modifications
+- Alert on changes to "In Scope" or "Done Criteria"
+
+**Automation Feasibility:** High (git diff on SOD file)
+
+---
+
+### 3. Timeline Slippage Patterns
+
+**Signal:** Repeated deadline extensions or "just one more sprint."
+
+**Detection Method:**
+- Track original deadline vs. current deadline
+- Count extension requests
+- Alert after N extensions (configurable threshold)
+
+**Automation Feasibility:** Medium (requires deadline tracking)
+
+---
+
+### 4. Solution Architecture Changes
+
+**Signal:** Fundamental approach changes during Execute.
+
+**Detection Method:**
+- Monitor for new ADRs (Architecture Decision Records)
+- Large-scale refactoring PRs during Execute
+- New dependencies added outside initial scope
+
+**Automation Feasibility:** Medium (can detect new ADRs, large PRs)
+
+---
+
+### 5. Stakeholder Churn
+
+**Signal:** New stakeholders joining with new requirements.
+
+**Detection Method:**
+- Track contributor list at Formalize
+- Alert when new stakeholders introduce scope items
+- Meeting frequency increase
+
+**Automation Feasibility:** Low (requires meeting/communication analysis)
+
+---
+
+### 6. "One More Feature" Pattern
+
+**Signal:** Informal requests accumulating without formal scope change.
+
+**Detection Method:**
+- Slack/email analysis for phrases like "can we also," "while you're at it"
+- Tracking informal asks vs. formal backlog items
+
+**Automation Feasibility:** Low (requires NLP on communications)
+
+---
+
+### 7. Budget/Resource Overruns
+
+**Signal:** Spending more than allocated without scope reduction.
+
+**Detection Method:**
+- Track hours/cost vs. budget
+- Alert at 80% threshold
+- Compare to original estimate
+
+**Automation Feasibility:** High (if time tracking exists)
+
+---
+
+### 8. Rabbit Hole Entry
+
+**Signal:** Work diverging into explicitly excluded areas.
+
+**Detection Method:**
+- Match PR descriptions/commit messages against "Out of Scope" items
+- Keyword matching on rabbit holes list
+- Code changes in excluded areas
+
+**Automation Feasibility:** Medium (keyword matching feasible)
+
+---
+
+## Automation Feasibility Assessment
+
+| Trigger | Automation Level | Implementation Complexity |
+|---------|------------------|---------------------------|
+| Scope expansion | High | Low - count issues |
+| Requirements drift | High | Low - git diff |
+| Timeline slippage | Medium | Medium - track dates |
+| Architecture changes | Medium | Medium - detect ADRs |
+| Budget overruns | High | Low - compare numbers |
+| Rabbit hole entry | Medium | Medium - keyword match |
+| Stakeholder churn | Low | High - requires integrations |
+| Informal requests | Low | High - requires NLP |
+
+### Recommended Priority
+
+1. **Start with:** Requirements drift detection (diff SOD on each commit)
+2. **Then add:** Scope expansion counting (issue tracker integration)
+3. **Later:** Architecture change detection (ADR monitoring)
+
+---
+
+## Detection Heuristics for `praxis validate`
+
+```yaml
+regression_heuristics:
+  # High confidence - can automate
+  sod_modified_during_execute:
+    trigger: "SOD file changed while stage >= execute"
+    action: "warn"
+    message: "SOD modified during Execute - possible regression to Formalize"
+
+  scope_items_increased:
+    trigger: "Issue count > count at formalize transition"
+    action: "warn"
+    message: "Scope expanded during Execute - review for regression"
+
+  # Medium confidence - alert for human review
+  new_adr_during_execute:
+    trigger: "New ADR created while stage >= execute"
+    action: "info"
+    message: "Architecture decision made during Execute - may indicate scope issue"
+
+  # Configurable thresholds
+  deadline_extensions:
+    trigger: "deadline_extension_count > threshold"
+    threshold: 2
+    action: "warn"
+    message: "Multiple deadline extensions - consider regression to Formalize"
+```
+
+---
+
+## How Other Frameworks Handle Regression
+
+### Stage-Gate (Cooper)
+- No regression allowed—gates are "go/kill" decisions
+- Failed gates = project killed
+- Praxis is more flexible by design
+
+### Agile/Scrum
+- Scope changes handled via backlog refinement
+- Sprint scope is locked, but backlog can change
+- Retrospectives catch process issues
+
+### Shape Up
+- Fixed time boxes act as "circuit breakers"
+- If not done in 6 weeks, project is killed or re-pitched
+- No scope extension by design
+
+### Key Insight
+Praxis is unique in explicitly *allowing* regression while still detecting it. Other frameworks either forbid regression (Stage-Gate) or handle it implicitly (Agile backlog churn).
+
+---
+
+## Proposed Implementation
+
+### Phase 1: Manual Alerts
+- Add regression warning messages to `praxis status`
+- Detect SOD modifications during Execute
+- Show time-since-last-stage-change
+
+### Phase 2: Automated Detection
+- Add `praxis validate --check-regression` flag
+- Integrate with git history for SOD diffs
+- Track issue counts if integration available
+
+### Phase 3: Predictive Alerts
+- Burndown trend analysis
+- Deadline slip pattern matching
+- Integration with project management tools
+
+---
+
+## Sources
+
+- [Scope Creep in Project Management - Monday.com](https://monday.com/blog/project-management/keep-scope-creep-undermining-project/)
+- [Project Management Scope Creep - TrueProject](https://www.trueprojectinsight.com/blog/project-office/project-management-scope-creep)
+- [How to Handle Scope Creep in Agile - DE Project Manager](https://deeprojectmanager.com/handle-scope-creep-in-agile-projects/)
+- [4 Ways to Deal with Scope Creep - Atlassian](https://www.atlassian.com/blog/inside-atlassian/4-how-tos-dealing-with-scope-creep)
+- [Reduce Scope Creep in Agile - Tempo](https://www.tempo.io/blog/scope-creep-in-agile)
+
+---
+
+## Follow-Up Recommendations
+
+1. **Add regression detection** to `praxis validate` (SOD diff check)
+2. **Create issue tracker integration spec** for scope counting
+3. **Add time-since-stage-change** to `praxis status` output
+4. **Define regression severity levels** (info vs. warn vs. error)

--- a/projects/write/opinions-framework/docs/01-refine-lifecycle-research-05-shape-up-report.md
+++ b/projects/write/opinions-framework/docs/01-refine-lifecycle-research-05-shape-up-report.md
@@ -1,0 +1,163 @@
+# Spike Report: Shape Up Deep Dive
+
+**Project:** opinions-framework
+**Spike:** #79 - Shape Up Deep Dive
+**Date:** 2025-12-28
+**Status:** Complete
+
+---
+
+## Executive Summary
+
+Mapped Shape Up methodology to Praxis stages. Found strong alignment with Shape/Formalize stages. Key divergences: Praxis supports multiple domains (not just software), has more granular stages, and allows explicit regression.
+
+---
+
+## Shape Up Overview
+
+Shape Up is Basecamp's product development methodology with three phases:
+
+1. **Shaping** - Senior people define problems and sketch solutions
+2. **Betting** - Leadership decides what to build in the next cycle
+3. **Building** - Teams execute with full autonomy for 6 weeks
+
+Key principles:
+- Fixed time, variable scope
+- No backlogs (pitches that aren't bet on are discarded)
+- Appetite-based scoping (how much is this worth?)
+- Circuit breaker (6 weeks max, then kill or re-pitch)
+
+---
+
+## Alignment Matrix
+
+| Shape Up Concept | Praxis Stage/Concept | Alignment |
+|------------------|---------------------|-----------|
+| **Shaping** | Shape | Strong |
+| **Pitch** | SOD (Formalize artifact) | Strong |
+| **Betting Table** | Formalize → Commit transition | Strong |
+| **Building** | Execute | Strong |
+| **Cooldown** | Sustain or Close | Partial |
+| **Appetite** | SOD constraints | Strong |
+| **Six-week cycle** | (no equivalent) | Diverge |
+| **No backlog** | (no equivalent) | Diverge |
+
+---
+
+## What Praxis Can Borrow
+
+### 1. Appetite-Based Scoping
+Shape Up uses "appetite" (how much time this is worth) rather than estimates (how long will this take). This inverts the typical planning question.
+
+**Recommendation:** Add "Appetite" as a required SOD section. Frame it as "How much effort is appropriate?" not "How long will this take?"
+
+### 2. Pitch Structure
+The Shape Up pitch has five ingredients:
+- Problem
+- Appetite
+- Solution
+- Rabbit holes
+- No-gos
+
+**Recommendation:** The SOD template should mirror this structure. Already proposed in Spike #76.
+
+### 3. Fixed Boundaries, Not Fixed Scope
+Shape Up teams cut scope to fit the time box, not extend time to fit scope. This is a mindset, not just a process.
+
+**Recommendation:** Add "scope cutting" as an explicit Execute activity in lifecycle.md. "If time runs out, cut features, don't extend deadlines."
+
+### 4. Circuit Breaker Pattern
+If work isn't done in 6 weeks, it's killed—no extensions by default. This prevents runaway projects.
+
+**Recommendation:** Consider optional "circuit breaker" setting in praxis.yaml that triggers automatic regression to Formalize if Execute exceeds threshold.
+
+---
+
+## Where Praxis Diverges (and Why)
+
+### 1. Multiple Domains
+Shape Up is designed for software product development. Praxis covers Code, Create, Write, Learn, and Observe.
+
+**Implication:** Shape Up's "Building" phase maps to Execute, but the definition of Execute varies by domain.
+
+### 2. More Granular Stages
+Shape Up has 3 phases. Praxis has 9 stages.
+
+**Implication:** Praxis captures early-stage work (Capture → Sense → Explore) that Shape Up skips. Shape Up assumes ideas arrive already somewhat shaped.
+
+### 3. Explicit Regression
+Shape Up kills projects that don't finish. Praxis allows regression to earlier stages.
+
+**Implication:** Praxis is more forgiving but requires regression detection (Spike #78) to prevent abuse.
+
+### 4. Backlogs Allowed
+Shape Up discards unbetted pitches. Praxis doesn't mandate backlog policy.
+
+**Implication:** Teams can choose Shape Up's "no backlog" approach or maintain traditional backlogs. Praxis is agnostic.
+
+### 5. Individual vs. Team Focus
+Shape Up assumes team-based work. Praxis works for solo projects too.
+
+**Implication:** "Betting table" concept doesn't translate to solo work. Praxis Formalize is the decision point.
+
+---
+
+## Appetite vs. Constraints
+
+| Shape Up | Praxis Equivalent |
+|----------|-------------------|
+| Small Batch (2 weeks) | size: small |
+| Big Batch (6 weeks) | size: medium or large |
+| Specific appetite ("2 weeks of one designer") | SOD constraints section |
+
+**Key insight:** Shape Up's appetite is about *commitment level*, not just time. "How much are we willing to lose if this fails?"
+
+**Recommendation:** Frame SOD "Appetite" as risk tolerance, not just duration.
+
+---
+
+## Relationship to Formalize Boundary
+
+Shape Up's "Betting Table" is equivalent to Praxis's Formalize → Commit transition:
+
+| Aspect | Shape Up | Praxis |
+|--------|----------|--------|
+| Decision point | Betting Table | Formalize stage exit |
+| Artifact required | Pitch | SOD |
+| Who decides | Senior leadership | (varies by project) |
+| Outcome if approved | Goes to Building | Advances to Commit |
+| Outcome if rejected | Discarded (by default) | Stays in Formalize or regresses |
+
+**Key insight:** The Formalize boundary is Praxis's version of the betting table, but without mandating who makes the decision.
+
+---
+
+## Borrowed Terms
+
+Consider adopting these Shape Up terms in Praxis:
+
+| Term | Meaning | Use In Praxis |
+|------|---------|---------------|
+| **Appetite** | How much we're willing to spend | SOD section |
+| **Rabbit holes** | Traps to avoid | SOD section (already adopted) |
+| **No-gos** | Explicitly excluded | SOD "Out of Scope" section |
+| **Circuit breaker** | Automatic kill if over time | Optional regression trigger |
+
+---
+
+## Sources
+
+- [Shape Up - Basecamp (full book PDF)](https://basecamp.com/shapeup/shape-up.pdf)
+- [The Betting Table - Shape Up Ch. 8](https://basecamp.com/shapeup/2.2-chapter-08)
+- [Write the Pitch - Shape Up Ch. 6](https://basecamp.com/shapeup/1.5-chapter-06)
+- [Bets, Not Backlogs - Shape Up Ch. 7](https://basecamp.com/shapeup/2.1-chapter-07)
+- [Shape Up Complete Guide 2024 - AgileFirst](https://agilefirst.io/what-is-shape-up/)
+
+---
+
+## Follow-Up Recommendations
+
+1. **Add "Appetite" to SOD template** (already in Spike #76)
+2. **Add scope cutting guidance** to lifecycle.md Execute section
+3. **Consider circuit breaker config** in praxis.yaml schema
+4. **Document Shape Up alignment** for teams familiar with that methodology


### PR DESCRIPTION
## Summary

Completed four spike research stories investigating key Praxis lifecycle concepts:

### Spike #76: SOD Template Research
- Compared SOD to PRD, BRD, RFC, and Design Docs
- Found SOD is not a standardized term—Praxis can define it as a lightweight formalization artifact
- Proposed minimum viable SOD template with 6 required sections: Background, Appetite, Solution, In Scope, Out of Scope, Done Criteria
- Strong alignment with Shape Up's "Pitch" format

### Spike #77: Sustain for Non-Code Domains
- Defined sustain patterns for Create (portfolio maintenance, format preservation), Write (version control, accuracy reviews), Learn (spaced repetition, deliberate practice), and Observe (curation, pruning)
- Key insight: Sustain ≠ Improvement. Sustain maintains current state; improvement requires returning to earlier stages
- Learn domain has the most mature science (spaced repetition systems)

### Spike #78: Regression Trigger Detection
- Identified 8 regression triggers with automation feasibility assessment
- High feasibility: SOD modifications during Execute, scope item count changes, budget overruns
- Medium feasibility: Architecture changes (ADRs), deadline slippage, rabbit hole entry
- Low feasibility: Stakeholder churn, informal request patterns
- Proposed `praxis validate --check-regression` implementation path

### Spike #79: Shape Up Deep Dive
- Strong alignment: Shape/Formalize stages map well to Shape Up's Shaping/Betting phases
- Key borrowings: Appetite-based scoping, Rabbit holes, Circuit breaker pattern
- Key divergences: Praxis supports multiple domains, allows explicit regression, has more granular stages

## Files Changed
- `projects/write/opinions-framework/docs/01-refine-lifecycle-research-02-sod-template-report.md`
- `projects/write/opinions-framework/docs/01-refine-lifecycle-research-03-sustain-non-code-report.md`
- `projects/write/opinions-framework/docs/01-refine-lifecycle-research-04-regression-detection-report.md`
- `projects/write/opinions-framework/docs/01-refine-lifecycle-research-05-shape-up-report.md`

## Decisions Made
- SOD template structure mirrors Shape Up pitch format (5 ingredients + Done Criteria)
- Sustain definitions are domain-specific with distinct triggers per domain
- Regression detection should start with SOD diff detection (highest feasibility)
- Praxis diverges from Shape Up by allowing regression instead of "kill or continue"

## Open Questions
- Should `praxis.yaml` include domain-specific sustain triggers?
- Should circuit breaker (auto-regression on timeout) be a configurable option?
- What threshold for deadline extensions should trigger regression warning?

## Follow-Up Recommendations
1. Create SOD template file in `docs/templates/sod.md`
2. Add domain-specific sustain guidance to `docs/domains.md`
3. Implement `praxis validate --check-regression` with SOD diff detection
4. Consider SRS integration for Learn domain sustain tracking

## Test Plan
- [x] Research reports are well-structured and complete
- [x] Each spike has sources cited
- [x] Definition of Done criteria met for all spikes

Closes #76
Closes #77
Closes #78
Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)